### PR TITLE
Set widget width in tab to 100%

### DIFF
--- a/assets/plugins/managermanager/widgets/evogallery/evogallery.php
+++ b/assets/plugins/managermanager/widgets/evogallery/evogallery.php
@@ -27,7 +27,7 @@ function mm_widget_evogallery($moduleid, $title='', $roles='', $templates='') {
                 else
                         $iframecontent = '<p class="warning">'.$_lang['mm_save_required'].'</p>';
                 
-                mm_createTab($title, 'evogallery', '', '', '<strong>Управление изображениями</strong>');
+                mm_createTab($title, 'evogallery', '', '', '<strong>Управление изображениями</strong>', '100%');
 
                 $output = "\$j('#table-evogallery').append('<tr><td>$iframecontent</td></tr>');";
     


### PR DESCRIPTION
Default tab width was too small to edit images
before ![before](http://i.imgur.com/LXK6JYX.png)
after ![after](http://i.imgur.com/V5RiHA2.png)